### PR TITLE
fix warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,8 @@ fn read_file(path: &str) -> Result<String, Error> {
     let mut file = File::open(path).unwrap();
     let mut buffer = String::new();
 
-    file.read_to_string(&mut buffer);
-
-    Ok(buffer)
+    match file.read_to_string(&mut buffer) {
+        Err(f) => { panic!(f.to_string()) }
+        _ => Ok(buffer)
+    }
 }


### PR DESCRIPTION
wrap in match and create panic message on failure.  otherwise ignore the count and return the result as before.
